### PR TITLE
Add a smidge of line-height

### DIFF
--- a/src/styles/application.sass
+++ b/src/styles/application.sass
@@ -157,6 +157,7 @@ a:not(.plain)
   &__answer
     display: none
     margin: 0.5em 0 0
+    line-height: 1.25
   &__checkbox:focus ~ &__question
     +highlight
   &__checkbox:checked ~ &__question:before
@@ -184,6 +185,7 @@ a:not(.plain)
     margin: 0 auto
     max-width: 800px
     font-size: 0.75em
+    line-height: 1.25
 
 .footer
   text-align: center


### PR DESCRIPTION
Hi! This is a totally unsolicited PR; it adds a lil bit of line height on the answers / research footnotes sections of the site where there's multi-line text; personally that tiny bit of extra gaps between lines makes things a bit easier to read. Please feel free to discard this though!

---

## Current Site
![Screenshot 2019-06-22 at 16 52 23](https://user-images.githubusercontent.com/1315466/59966080-c5ac6080-950e-11e9-8cdf-b9725b738167.png)

## This PR
![Screenshot 2019-06-22 at 16 54 19](https://user-images.githubusercontent.com/1315466/59966083-ce049b80-950e-11e9-8261-fc67a9b027de.png)

---

Your milage may vary. Keep up the magnet finger lifestyle! 🤙 